### PR TITLE
writing: add launch links to HN history blogpost

### DIFF
--- a/src/content/post/history-of-hnsearch.mdx
+++ b/src/content/post/history-of-hnsearch.mdx
@@ -9,7 +9,19 @@ tags:
   - hackernews
 ---
 
+import TextBox from '../../components/common/TextBox.astro';
+
 We at Trieve are going to be launching a search engine for HackerNews with some additional features soon and thought it would be worth studying the history of HN search before finalizing things. Here's what we found!
+
+<TextBox class="border-fuchsia-200 dark:border-fuchsia-500 bg-fuchsia-50 dark:bg-fuchsia-700 text-fuchsia-900 dark:text-fuchsia-100">
+
+#### Update!
+
+We launched at the end of August! Check it out at [hn.trieve.ai](https://hn.trieve.ai).
+
+Here's [a writeup on the launch](https://trieve.ai/launching-trieve-hn-discovery/) ([HN post](https://news.ycombinator.com/item?id=41393005)).
+
+</TextBox>
 
 > Note: Did the research using our own HN search engine! :)
 


### PR DESCRIPTION
Version in this PR looks like this, adding the styled TextBox:
<img width="795" alt="image" src="https://github.com/user-attachments/assets/6a373bb2-6fba-4096-900e-b1a543405441">
