### PR TITLE
add mobile responsiveness to ImageComparison component

### DIFF
--- a/src/components/common/ImageComparison.astro
+++ b/src/components/common/ImageComparison.astro
@@ -11,7 +11,6 @@ interface Props {
   leftLink: string;
   rightLink: string;
   query: string;
-  size: 'small' | 'medium' | 'large';
   leftStyles?: string;
   rightStyles?: string;
   preventShrink?: boolean;
@@ -27,21 +26,19 @@ const {
   leftLink,
   rightLink,
   query,
-  size,
   leftStyles,
   rightStyles,
   preventShrink = false,
 } = Astro.props;
 
-const containerClasses = size === 'medium' ? 'ml-4' : '';
-const imageClasses = `w-full h-auto m-0 border cursor-pointer${preventShrink ? ' min-w-[400px] min-h-[300px]' : ''}`;
+const imageClasses = `w-full h-auto m-0 border cursor-pointer${preventShrink ? ' min-w-[200px] min-h-[150px]' : ''}`;
 const widthValue = preventShrink ? 'auto' : 400;
 const heightValue = 300;
 ---
 
-<div class={`mx-auto max-w-3xl mb-5 ${containerClasses}`}>
-  <div class="flex justify-between">
-    <div class="w-[49%] image-container">
+<div class="mx-auto max-w-3xl mb-5">
+  <div class="flex flex-wrap justify-center gap-4">
+    <div class="flex-grow flex-shrink-0 basis-[300px] max-w-full image-container">
       <figure class="m-0">
         <figcaption class="mb-2 text-center">
           <small>{leftCaption} <a href={leftLink} target="_blank">{query}</a></small>
@@ -52,11 +49,11 @@ const heightValue = 300;
           class={`${imageClasses} ${leftStyles}`}
           width={widthValue}
           height={heightValue}
-          aspectRatio={preventShrink ? "10:7" : undefined}
+          aspectRatio={preventShrink ? '10:7' : undefined}
         />
       </figure>
     </div>
-    <div class="w-[49%] image-container">
+    <div class="flex-grow flex-shrink-0 basis-[300px] max-w-full image-container">
       <figure class="m-0">
         <figcaption class="mb-2 text-center">
           <small
@@ -76,7 +73,7 @@ const heightValue = 300;
           class={`${imageClasses} ${rightStyles}`}
           width={widthValue}
           height={heightValue}
-          aspectRatio={preventShrink ? "10:7" : undefined}
+          aspectRatio={preventShrink ? '10:7' : undefined}
         />
       </figure>
     </div>

--- a/src/content/post/building-blazingly-fast-typo-correction-in-rust.mdx
+++ b/src/content/post/building-blazingly-fast-typo-correction-in-rust.mdx
@@ -1,7 +1,11 @@
 ---
 publishDate: 2024-09-09T08:45:00Z
 author: densumesh
+<<<<<<< HEAD
 title: How we Built 300μs Typo Detection for 1.3M Words in Rust
+=======
+title: How we Built 300μs Typo Correction for 1.3M Words in Rust
+>>>>>>> aab659b (cleanup: add number for misspelling to brief + cleanup navbar)
 excerpt: We explain how we built blazingly fast spellcheck in Rust using BKTrees, Redis queues, and Clickhouse in this blog.
 image: https://cdn.trieve.ai/blog/building-30%CE%BCs-typo-tolerance-for-1.3M-words%20using%20Rust/building-30us-typo-tolerance-cover.webp
 tags:
@@ -13,7 +17,11 @@ displayImage: false
 displayExcerpt: false
 ---
 
+<<<<<<< HEAD
 We launched our [Hacker News search and RAG engine](https://hn.trieve.ai) with a half-baked typo correction system. Our first draft took 30+ms for correctly spelled queries which was slow enough that we defaulted it to off. Our latest version is 100 times faster, 300μs for correctly spelled queries and ~5ms/word for misspellings. We explain how it was accomplished in this post!
+=======
+We launched our [Hacker News search and RAG engine](https://hn.trieve.ai) with a half-baked typo correction system. Our first draft took 30+ms for correctly spelled queries which was slow enough that we defaulted it to off. Our latest version is 100 times faster, 300μs for corrrectly spelled queries and ~5ms/word for misspellings. We explain how it was accomplished in this post!
+>>>>>>> aab659b (cleanup: add number for misspelling to brief + cleanup navbar)
 
 ![video demo of spellcheck](https://cdn.trieve.ai/blog/building-30%CE%BCs-typo-tolerance-for-1.3M-words%20using%20Rust/typo-tolerance-demo.gif)
 

--- a/src/content/post/building-blazingly-fast-typo-correction-in-rust.mdx
+++ b/src/content/post/building-blazingly-fast-typo-correction-in-rust.mdx
@@ -1,11 +1,7 @@
 ---
 publishDate: 2024-09-09T08:45:00Z
 author: densumesh
-<<<<<<< HEAD
 title: How we Built 300μs Typo Detection for 1.3M Words in Rust
-=======
-title: How we Built 300μs Typo Correction for 1.3M Words in Rust
->>>>>>> aab659b (cleanup: add number for misspelling to brief + cleanup navbar)
 excerpt: We explain how we built blazingly fast spellcheck in Rust using BKTrees, Redis queues, and Clickhouse in this blog.
 image: https://cdn.trieve.ai/blog/building-30%CE%BCs-typo-tolerance-for-1.3M-words%20using%20Rust/building-30us-typo-tolerance-cover.webp
 tags:
@@ -17,11 +13,7 @@ displayImage: false
 displayExcerpt: false
 ---
 
-<<<<<<< HEAD
 We launched our [Hacker News search and RAG engine](https://hn.trieve.ai) with a half-baked typo correction system. Our first draft took 30+ms for correctly spelled queries which was slow enough that we defaulted it to off. Our latest version is 100 times faster, 300μs for correctly spelled queries and ~5ms/word for misspellings. We explain how it was accomplished in this post!
-=======
-We launched our [Hacker News search and RAG engine](https://hn.trieve.ai) with a half-baked typo correction system. Our first draft took 30+ms for correctly spelled queries which was slow enough that we defaulted it to off. Our latest version is 100 times faster, 300μs for corrrectly spelled queries and ~5ms/word for misspellings. We explain how it was accomplished in this post!
->>>>>>> aab659b (cleanup: add number for misspelling to brief + cleanup navbar)
 
 ![video demo of spellcheck](https://cdn.trieve.ai/blog/building-30%CE%BCs-typo-tolerance-for-1.3M-words%20using%20Rust/typo-tolerance-demo.gif)
 


### PR DESCRIPTION
Current: 
<img width="473" alt="image" src="https://github.com/user-attachments/assets/3cb18689-512c-45c3-af4b-ba9e370d7ddf">

This PR:
<img width="452" alt="image" src="https://github.com/user-attachments/assets/9470a995-e5af-4b02-8914-d1862a7f5878">
